### PR TITLE
日をまたぐ予定のおかしい時刻表示を修正 (fix #3)

### DIFF
--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -98,6 +98,29 @@ AlarmUtil.onRefreshScheduleAlarm.addListener(() => {
 chrome.runtime.onInstalled.addListener(details => {
 	AlarmUtil.startRefreshScheduleAlarm();
 
+	if (details.reason === 'update') {
+		if (details.previousVersion === '0.5.0') {
+			// 0.5.0 からのアップデートでScheduleのid仕様が変わっているため、新idでも保存し直す
+			chrome.storage.local.get([
+				'scheduleCache',
+			], ({
+				scheduleCache,
+			}) => {
+				if (scheduleCache) {
+					for (const rawSchedule of Object.values(scheduleCache.scheduleById)) {
+						const schedule = Schedule.parse(rawSchedule);
+						scheduleCache.scheduleById[schedule.id] = schedule;
+					}
+
+					chrome.storage.local.set({
+						scheduleCache,
+					});
+				}
+			});
+		}
+		return;
+	}
+
 	if (details.reason === 'install') {
 		chrome.runtime.openOptionsPage();
 	}

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -22,7 +22,7 @@ AlarmUtil.onScheduleNotificationAlarm.addListener(alarm => {
 				const schedule = Schedule.parse(scheduleCache.scheduleById[scheduleId]);
 				const facility = schedule.findFromOptions('施設');
 
-				chrome.notifications.create(scheduleId, {
+				chrome.notifications.create(schedule.id, {
 					title: schedule.title,
 					message: facility || '',
 					contextMessage: schedule.time,

--- a/chrome-extension/js/Schedule.js
+++ b/chrome-extension/js/Schedule.js
@@ -3,18 +3,21 @@ class Schedule {
 	/**
 	 *
 	 * @param {object} schedule - original schedule data
+	 * @param {string} date YYYY-MM-DD 複数日にまたがる予定の場合に区別するための日付
 	 */
-	constructor(schedule) {
+	constructor(schedule, date) {
 		this._originalData = schedule;
+		this._date = date;
 	}
 
 	/**
 	 * @param {object} arg
 	 * @param {object} arg._originalData
+	 * @param {string} arg._date YYYY-MM-DD
 	 * @returns {Schedule} aa
 	 */
 	static parse(arg) {
-		return new this(arg._originalData);
+		return new this(arg._originalData, arg._date);
 	}
 
 	/**
@@ -31,7 +34,7 @@ class Schedule {
 		if (this.isValid) {
 			const resid = this._originalData.record.resid;
 			const target = this._originalData.record.target;
-			return `${resid}:${target}`;
+			return `${resid}:${target}:${this._date}`;
 		}
 	}
 

--- a/chrome-extension/js/displayEvents.js
+++ b/chrome-extension/js/displayEvents.js
@@ -50,7 +50,7 @@ window.displayEvents = (dailySchedules, scheduleById, targetUrl, lastModified, o
 		container.append(h1);
 		scheduleIds.forEach(scheduleId => {
 			const schedule = scheduleById[scheduleId];
-			const url = `${targetUrl}aqua/${schedule.resid}/view?target=${date}`;
+			const url = `${targetUrl}aqua/${schedule.resid}/view?target=${schedule.targetDate}`;
 
 			const p = document.createElement('p');
 			p.append(schedule.time);

--- a/chrome-extension/js/fetchSchedule.js
+++ b/chrome-extension/js/fetchSchedule.js
@@ -32,9 +32,9 @@ window.fetchSchedule = (targetUrl) => {
 		throw 'おそらくログインしてない';
 	}).then(json => {
 		const scheduleById = {};
-		for (const event of Object.values(json.events)) {
+		for (const [date, event] of Object.entries(json.events)) {
 			for (const s of event.schedules) {
-				const schedule = new Schedule(s);
+				const schedule = new Schedule(s, date);
 				if (schedule.isValid) {
 					scheduleById[schedule.id] = schedule;
 				}
@@ -46,7 +46,7 @@ window.fetchSchedule = (targetUrl) => {
 			if (date1 < date2) return -1;
 			return 0;
 		}).map(([date, {schedules}]) => {
-			const scheduleIds = schedules.map(s => new Schedule(s)).filter(schedule => schedule.isValid).map(schedule => schedule.id);
+			const scheduleIds = schedules.map(s => new Schedule(s, date)).filter(schedule => schedule.isValid).map(schedule => schedule.id);
 			return {
 				date,
 				scheduleIds,


### PR DESCRIPTION
#3 を修正

例）2018年6月8日(金) 23:00 ～ 9日(土) 01:30 の予定

![image](https://user-images.githubusercontent.com/13145001/41155403-c4fe1fe2-6b58-11e8-8514-beb25bd30734.png)
